### PR TITLE
Add Ability to Make Utility Objects Global

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 - Basic technique viewer with texture list by @cohaereo
 - Implement map resources Unk80808246 and Unk80806ac2 by @cohaereo
 - Add Delete Button on Inspector Panel by @Froggy618157725 in [#11](https://github.com/cohaereo/alkahest/pull/11)
+- Add Global Utility Objects by @Froggy618167725 in [#12](https://github.com/cohaereo/alkahest/pull/12)
 
 ### Changed
 
@@ -44,3 +45,4 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)
 
 - Fix camera right and up axis by @cohaereo
 - Fix Utility Visibility by @Froggy618157725 in [#10](https://github.com/cohaereo/alkahest/pull/10)
+- Fixed Sphere Icon in Inspector Panel by @Froggy618167725 in [#12](https://github.com/cohaereo/alkahest/pull/12)

--- a/src/ecs/component_panels.rs
+++ b/src/ecs/component_panels.rs
@@ -111,11 +111,7 @@ pub fn show_inspector_panel(
         ui.separator();
     }
 
-    let mut global = if let Some(g) = e.get::<&Global>() {
-        g.0
-    } else {
-        false
-    };
+    let mut global = e.get::<&Global>().map_or(false, |g| g.0);
     if e.has::<Mutable>() {
         if ui.checkbox(&mut global, "Show in all Maps").clicked() {
             if let Some(mut g) = e.get::<&mut Global>() {

--- a/src/ecs/component_panels.rs
+++ b/src/ecs/component_panels.rs
@@ -20,8 +20,8 @@ use crate::{
 
 use super::{
     components::{
-        EntityModel, EntityWorldId, Label, Mutable, ResourcePoint, Ruler, Sphere, StaticInstances,
-        Visible,
+        EntityModel, EntityWorldId, Global, Label, Mutable, ResourcePoint, Ruler, Sphere,
+        StaticInstances, Visible,
     },
     resolve_entity_icon, resolve_entity_name,
     tags::Tags,
@@ -40,6 +40,7 @@ pub fn show_inspector_panel(
     };
 
     let mut add_visible = None;
+    let mut add_global = None;
     let mut delete = false;
     let mut add_label = false;
     ui.horizontal(|ui| {
@@ -110,6 +111,21 @@ pub fn show_inspector_panel(
         ui.separator();
     }
 
+    let mut global = if let Some(g) = e.get::<&Global>() {
+        g.0
+    } else {
+        false
+    };
+    if e.has::<Mutable>() {
+        if ui.checkbox(&mut global, "Show in all Maps").clicked() {
+            if let Some(mut g) = e.get::<&mut Global>() {
+                g.0 = global;
+            } else {
+                add_global = Some(Global(global));
+            }
+        };
+        ui.separator();
+    }
     show_inspector_components(ui, e, resources);
 
     if add_label {
@@ -120,6 +136,10 @@ pub fn show_inspector_panel(
 
     if let Some(vis) = add_visible {
         scene.insert_one(ent, vis).ok();
+    }
+
+    if let Some(g) = add_global {
+        scene.insert_one(ent, g).ok();
     }
 
     if delete {

--- a/src/ecs/components.rs
+++ b/src/ecs/components.rs
@@ -74,21 +74,28 @@ pub struct StaticInstances(pub InstancedRenderer, pub TagHash);
 
 pub struct Water;
 
-pub struct Visible(pub bool);
+macro_rules! bool_trait {
+    ($name: ident) => {
+        pub struct $name(pub bool);
 
-impl Deref for Visible {
-    type Target = bool;
+        impl Deref for $name {
+            type Target = bool;
 
-    fn deref(&self) -> &Self::Target {
-        &self.0
-    }
+            fn deref(&self) -> &Self::Target {
+                &self.0
+            }
+        }
+
+        impl DerefMut for $name {
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                &mut self.0
+            }
+        }
+    };
 }
 
-impl DerefMut for Visible {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.0
-    }
-}
+bool_trait!(Visible);
+bool_trait!(Global);
 
 pub struct Ruler {
     pub start: Vec3,

--- a/src/ecs/mod.rs
+++ b/src/ecs/mod.rs
@@ -63,7 +63,7 @@ pub fn resolve_entity_name(e: EntityRef<'_>, append_ent: bool) -> String {
             };
         }
 
-        name_from_component_panels!(Ruler, EntityModel, StaticInstances);
+        name_from_component_panels!(Ruler, Sphere, EntityModel, StaticInstances);
 
         format!("ent {}", e.entity().id())
     }

--- a/src/ecs/mod.rs
+++ b/src/ecs/mod.rs
@@ -33,6 +33,7 @@ pub fn resolve_entity_icon(e: EntityRef<'_>) -> Option<char> {
         // TODO(cohae): Custom havok icon
         // HavokShape,
         Ruler,
+        Sphere,
         EntityModel,
         StaticInstances
     );

--- a/src/map.rs
+++ b/src/map.rs
@@ -46,11 +46,7 @@ impl MapDataList {
     }
 
     pub fn map_mut(&mut self, i: usize) -> Option<&mut MapData> {
-        if self.maps.is_empty() || i >= self.maps.len() {
-            None
-        } else {
-            self.maps.get_mut(i).map(|v| &mut v.2)
-        }
+        self.maps.get_mut(i).map(|v| &mut v.2)
     }
 }
 

--- a/src/map.rs
+++ b/src/map.rs
@@ -44,6 +44,14 @@ impl MapDataList {
             self.maps.get_mut(map_index).map(|v| &mut v.2)
         }
     }
+
+    pub fn map_mut(&mut self, i: usize) -> Option<&mut MapData> {
+        if self.maps.is_empty() || i >= self.maps.len() {
+            None
+        } else {
+            self.maps.get_mut(i).map(|v| &mut v.2)
+        }
+    }
 }
 
 #[derive(BinRead, Debug)]

--- a/src/overlays/render_settings.rs
+++ b/src/overlays/render_settings.rs
@@ -357,22 +357,17 @@ impl Overlay for RenderSettingsOverlay {
 
                     let mut ent_list = vec![];
 
-                    for (entity, global) in old_scene.query::<Option<&Global>>().iter() {
-                        if let Some(g) = global {
-                            if g.0 {
-                                ent_list.push(entity);
-                            }
+                    for (entity, global) in old_scene.query::<&Global>().iter() {
+                        if global.0 {
+                            ent_list.push(entity);
                         }
                     }
 
                     let mut selected = resources.get_mut::<SelectedEntity>().unwrap();
                     if let Some(map) = maps.current_map_mut() {
                         for entity in ent_list {
-                            let new_ent = map.scene.reserve_entity();
-                            map.scene
-                                .insert(new_ent, old_scene.take(entity).ok().unwrap())
-                                .ok();
-                            if selected.0.is_some_and(|e| e == entity) {
+                            let new_ent = map.scene.spawn(old_scene.take(entity).ok().unwrap());
+                            if selected.0 == Some(entity) {
                                 selected.0.replace(new_ent);
                             }
                         }

--- a/src/overlays/render_settings.rs
+++ b/src/overlays/render_settings.rs
@@ -3,12 +3,18 @@ use glam::{Mat4, Vec3, Vec4};
 use hecs::Entity;
 use itertools::Itertools;
 use nohash_hasher::{IntMap, IntSet};
-use std::{fmt::Display, fmt::Formatter, mem::transmute, time::Instant};
+use std::{
+    fmt::Display,
+    fmt::Formatter,
+    mem::{swap, take, transmute},
+    time::Instant,
+};
 use winit::window::Window;
 
 use crate::{
     discord,
-    ecs::components::ActivityGroup,
+    ecs::components::{ActivityGroup, Global},
+    ecs::resources::SelectedEntity,
     map::MapDataList,
     render::{
         overrides::{EnabledShaderOverrides, ScopeOverrides},
@@ -329,6 +335,7 @@ impl Overlay for RenderSettingsOverlay {
             let mut maps = resources.get_mut::<MapDataList>().unwrap();
             if !maps.maps.is_empty() {
                 let mut current_map = maps.current_map;
+                let old_map_index = current_map;
                 let map_changed = egui::ComboBox::from_label("Map")
                     .width(192.0)
                     .show_index(ui, &mut current_map, maps.maps.len(), |i| {
@@ -342,6 +349,39 @@ impl Overlay for RenderSettingsOverlay {
                 ));
 
                 maps.current_map = current_map;
+
+                // Move the Globals from the old scene to the new scene
+                if map_changed {
+                    // We have learned the power to Take worlds
+                    let mut old_scene = take(&mut maps.map_mut(old_map_index).unwrap().scene);
+
+                    let mut ent_list = vec![];
+
+                    for (entity, global) in old_scene.query::<Option<&Global>>().iter() {
+                        if let Some(g) = global {
+                            if g.0 {
+                                ent_list.push(entity);
+                            }
+                        }
+                    }
+
+                    let mut selected = resources.get_mut::<SelectedEntity>().unwrap();
+                    if let Some(map) = maps.current_map_mut() {
+                        for entity in ent_list {
+                            let new_ent = map.scene.reserve_entity();
+                            map.scene
+                                .insert(new_ent, old_scene.take(entity).ok().unwrap())
+                                .ok();
+                            if selected.0.is_some_and(|e| e == entity) {
+                                selected.0.replace(new_ent);
+                            }
+                        }
+                    }
+                    swap(
+                        &mut old_scene,
+                        &mut maps.map_mut(old_map_index).unwrap().scene,
+                    );
+                }
 
                 #[cfg(feature = "discord_rpc")]
                 if map_changed {


### PR DESCRIPTION
Utility Objects can now be tagged as global by checking "Show in all Maps"
This will cause the object to continue showing as you swap maps.
Also fixed an issue with the Sphere icon not showing in inspector pane.