### PR TITLE
Fix Renderer Settings on Startup

### DIFF
--- a/crates/alkahest/src/app.rs
+++ b/crates/alkahest/src/app.rs
@@ -104,6 +104,7 @@ impl AlkahestApp {
             false,
         )
         .unwrap();
+        renderer.set_render_settings(config::with(|c|{c.renderer.clone()}));
         resources.insert(renderer.clone());
         let stringmap = Arc::new(GlobalStringmap::load());
         resources.insert(stringmap);


### PR DESCRIPTION
The settings weren't applied unless the settings menu was open. Oops.