### PR TITLE
Add Node Filter for Utility Shapes

### DIFF
--- a/crates/alkahest-renderer/src/ecs/tags.rs
+++ b/crates/alkahest-renderer/src/ecs/tags.rs
@@ -8,8 +8,8 @@ use super::Scene;
 use crate::{
     icons::{
         ICON_ACCOUNT_CONVERT, ICON_CHESS_PAWN, ICON_DROPBOX, ICON_HELP, ICON_LIGHTBULB_ON,
-        ICON_PINE_TREE, ICON_REPLY, ICON_SKULL, ICON_SPHERE, ICON_TAG, ICON_VOLUME_HIGH,
-        ICON_WEATHER_PARTLY_CLOUDY,
+        ICON_PINE_TREE, ICON_REPLY, ICON_SKULL, ICON_SPHERE, ICON_TAG, ICON_TOOLBOX,
+        ICON_VOLUME_HIGH, ICON_WEATHER_PARTLY_CLOUDY,
     },
     util::color::Color,
 };
@@ -32,6 +32,8 @@ pub enum NodeFilter {
     NamedArea,
     SlipSurfaceVolume,
 
+    Utility,
+
     Unknown,
 }
 
@@ -50,6 +52,7 @@ impl NodeFilter {
             NodeFilter::PlayerContainmentVolume => ICON_DROPBOX,
             NodeFilter::NamedArea => ICON_TAG,
             NodeFilter::SlipSurfaceVolume => ICON_HELP,
+            NodeFilter::Utility => ICON_TOOLBOX,
             NodeFilter::Unknown => ICON_HELP,
         }
     }
@@ -70,6 +73,7 @@ impl NodeFilter {
             }
             NodeFilter::NamedArea => Color::from_srgba_unmultiplied(0, 127, 0, 255),
             NodeFilter::SlipSurfaceVolume => Color::from_srgba_unmultiplied(96, 96, 255, 255),
+            NodeFilter::Utility => Color::from_srgba_unmultiplied(119, 142, 160, 255),
             NodeFilter::Unknown => Color::from_srgba_unmultiplied(255, 255, 255, 255),
         }
     }

--- a/crates/alkahest/src/gui/menu/utility.rs
+++ b/crates/alkahest/src/gui/menu/utility.rs
@@ -3,7 +3,7 @@ use crate::maplist::MapList;
 use alkahest_renderer::camera::Camera;
 use alkahest_renderer::ecs::common::{Global, Icon, Label, Mutable};
 use alkahest_renderer::ecs::resources::SelectedEntity;
-use alkahest_renderer::ecs::tags::{EntityTag, Tags};
+use alkahest_renderer::ecs::tags::{EntityTag, NodeFilter, Tags};
 use alkahest_renderer::ecs::transform::{Transform, TransformFlags};
 use alkahest_renderer::ecs::utility::{Beacon, Route, RouteNode, Ruler, Sphere, Utility};
 use alkahest_renderer::ecs::SceneInfo;
@@ -31,6 +31,7 @@ impl MenuBar {
             if let Some(map) = maps.current_map_mut() {
                 let position_base = camera.position() + camera.forward() * 15.0;
                 let e = map.scene.spawn((
+                    NodeFilter::Utility,
                     if pos.is_finite() {
                         Ruler {
                             start: camera.position(),
@@ -68,6 +69,7 @@ impl MenuBar {
                 let camera = resources.get::<Camera>();
                 let position_base = camera.position() + camera.forward() * 24.0;
                 let e = map.scene.spawn((
+                    NodeFilter::Utility,
                     Transform {
                         translation: if distance > 24.0 { position_base } else { pos },
                         scale: Vec3::splat(9.0),
@@ -99,6 +101,7 @@ impl MenuBar {
             if let Some(map) = maps.current_map_mut() {
                 let camera = resources.get::<Camera>();
                 let e = map.scene.spawn((
+                    NodeFilter::Utility,
                     Transform {
                         translation: if distance > 24.0 {
                             camera.position()
@@ -129,6 +132,7 @@ impl MenuBar {
 
             if let Some(map) = maps.current_map_mut() {
                 let e = map.scene.spawn((
+                    NodeFilter::Utility,
                     Route {
                         path: vec![RouteNode {
                             pos: camera.position(),


### PR DESCRIPTION
Since they aren't in the pickbuffer at the moment, these can only be selected by filtering on the outliner. This adds a second way, by allowing you to show clickable labels from them, without them falling under "unknown", which drives my framerate down to the single digits most of the time...